### PR TITLE
Backward compatible change that introduces new structure spawn events to register for.

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksEvent.java
@@ -35,6 +35,7 @@ public class GetStructureTemplateBlocksEvent implements Event {
     private BlockRegionTransform transformation;
     /**
      * Final placement position to final block type map: The transformation is already applied.
+     * The position is the coordinate of the block in the world.
      */
     private Map<Vector3i, Block> blocksToPlace = new HashMap<>();
 

--- a/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.math.Region3i;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
+import org.terasology.world.block.Block;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Send this event to a structure template entity to determine the blocks that should be placed.
+ *
+ * Based on the components of a structure template, systems will fill this map.
+ *
+ * The blocks in the map have the transformation applied.
+ */
+public class GetStructureTemplateBlocksEvent implements Event {
+    private BlockRegionTransform transformation;
+    /**
+     * Final placement position to final block type map: The transformation is already applied.
+     */
+    private Map<Vector3i, Block> blocksToPlace = new HashMap<>();
+
+    public GetStructureTemplateBlocksEvent(BlockRegionTransform transform) {
+        this.transformation = transform;
+    }
+
+    public BlockRegionTransform getTransformation() {
+        return transformation;
+    }
+
+    public Map<Vector3i, Block> getBlocksToPlace() {
+        return blocksToPlace;
+    }
+
+    public void fillRegion(Region3i region, Block block) {
+        for (Vector3i pos : region) {
+            blocksToPlace.put(pos, block);
+        }
+    }
+}

--- a/src/main/java/org/terasology/structureTemplates/events/SpawnStructureEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/SpawnStructureEvent.java
@@ -16,12 +16,28 @@
 package org.terasology.structureTemplates.events;
 
 import org.terasology.entitySystem.event.Event;
-import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
 
 /**
- * When sent to entities with components like {@link SpawnBlockRegionsComponent} then the structure described by
- * that entity will be generated.
+ * Send this event to a structure template entity to start the spawning of the structure.
+ *
+ * On priority {@link EventPriority#PRIORITY_CRITICAL} there is a event handler that sends a
+ * {@link StructureSpawnStartedEvent}. Implement a handler of {@link StructureSpawnStartedEvent} when you
+ * want to add a component that does something when the spawning of a structure starts .(e.g. placing some spawn
+ * particles or playing a placement sound)
+ *
+ * On priority {@link EventPriority#PRIORITY_TRIVIAL} a handler of this event will send a
+ * {@link StructureBlocksSpawnedEvent}.
+ *
+ * If you want to introduce a component that makes structure templates spawn entities you should
+ * subscribe to this event. At least if it is not just a "spawning started" effect.
+ *
+ * Please note: the usage of this component will be changed, please do not add systtems that subscribe for this event.
+ *
+ * In future it will made a consumable event, and it will be up to the implementor of the consumable event
+ * when it will send the  {@link StructureBlocksSpawnedEvent} event. e.g. a system might place the blocks
+ * over a larger time frame and only when it is done the entities will be placed.
  */
 public class SpawnStructureEvent implements Event {
     private BlockRegionTransform transformation;

--- a/src/main/java/org/terasology/structureTemplates/events/StructureBlocksSpawnedEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/StructureBlocksSpawnedEvent.java
@@ -19,7 +19,7 @@ import org.terasology.entitySystem.event.Event;
 import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
 
 /**
- * Gets sen when the basic blocks of a structure template got placed. Event handlers
+ * Gets send when the basic blocks of a structure template got placed. Event handlers
  * typically add then entities that rely on the blocks being present.
  */
 public class StructureBlocksSpawnedEvent implements Event {

--- a/src/main/java/org/terasology/structureTemplates/events/StructureBlocksSpawnedEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/StructureBlocksSpawnedEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
+
+/**
+ * Gets sen when the basic blocks of a structure template got placed. Event handlers
+ * typically add then entities that rely on the blocks being present.
+ */
+public class StructureBlocksSpawnedEvent implements Event {
+    private BlockRegionTransform transformation;
+
+    public StructureBlocksSpawnedEvent(BlockRegionTransform transform) {
+        this.transformation = transform;
+    }
+
+    public BlockRegionTransform getTransformation() {
+        return transformation;
+    }
+}

--- a/src/main/java/org/terasology/structureTemplates/events/StructureSpawnStartedEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/StructureSpawnStartedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.events;
+
+import org.terasology.entitySystem.event.Event;
+import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
+
+/**
+ * The event gets sent to a structure template entity when a structure template spawning process started.
+ *
+ * Implement a handler of {@link StructureSpawnStartedEvent} when you
+ * want to add a structure template component that does something when the spawning of a structure starts .
+ * (e.g. placing some spawn particles or playing a placement sound)
+ */
+public class StructureSpawnStartedEvent implements Event {
+    private BlockRegionTransform transformation;
+
+    public StructureSpawnStartedEvent(BlockRegionTransform transform) {
+        this.transformation = transform;
+    }
+
+    public BlockRegionTransform getTransformation() {
+        return transformation;
+    }
+}

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/AddItemsToChestSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/AddItemsToChestSystem.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
@@ -29,7 +28,7 @@ import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.In;
 import org.terasology.structureTemplates.components.AddItemsToChestComponent;
-import org.terasology.structureTemplates.events.SpawnStructureEvent;
+import org.terasology.structureTemplates.events.StructureBlocksSpawnedEvent;
 import org.terasology.structureTemplates.util.transform.BlockRegionTransform;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.block.items.BlockItemFactory;
@@ -50,9 +49,9 @@ public class AddItemsToChestSystem extends BaseComponentSystem {
     @In
     private InventoryManager inventoryManager;
 
-    @ReceiveEvent(priority = EventPriority.PRIORITY_LOW)
-    public void onSpawnStructureEvent(SpawnStructureEvent event, EntityRef entity,
-                                    AddItemsToChestComponent component) {
+    @ReceiveEvent
+    public void onSpawnStructureEvent(StructureBlocksSpawnedEvent event, EntityRef entity,
+                                      AddItemsToChestComponent component) {
         BlockRegionTransform transformation = event.getTransformation();
 
         BlockItemFactory blockFactory = new BlockItemFactory(entityManager);


### PR DESCRIPTION
This makes it more extendable and allows for a future API breaking change
that makes it even more flexible.

There is a new GetStructureTemplateBlocks that components can handle to
modify the blocks that get placed by a structure template.

This patch adds other events systems that want to contribute to the
structure spawn process can register for.

The StructureSpwnStartedEvent gets send when the structure spawning starts
and StructureBlocksSpawnedEvent gets send when the blocks get placed.

The actual SpawnStructureEvent can then later be made consumable.
In future a system might consume the SpawnStructureEvent and do a
delayed block placement until it sends a StructureBlocksSpawnedEvent.