### PR TITLE
Add replication to the ProtectedRegionsComponent

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/components/ProtectedRegionsComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/ProtectedRegionsComponent.java
@@ -17,12 +17,14 @@ package org.terasology.structureTemplates.components;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.math.Region3i;
+import org.terasology.network.Replicate;
 
 import java.util.List;
 
 /**
  * Prevents modification of certain absolute regions as long as the entity that owns it exists.
  */
+@Replicate
 public class ProtectedRegionsComponent implements Component {
     public List<Region3i> regions;
 


### PR DESCRIPTION
Adds replication in order to be seen by a client for usage in detection for Scenario module. Allows a client to actually see if the component exists on an entity or not.