### PR TITLE
Fixes ST working with new block families

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
@@ -76,7 +76,7 @@ import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.entity.placement.PlaceBlocks;
 import org.terasology.world.block.family.BlockFamily;
-import org.terasology.world.block.family.HorizontalBlockFamily;
+import org.terasology.world.block.family.HorizontalFamily;
 import org.terasology.world.block.items.BlockItemComponent;
 import org.terasology.world.block.items.OnBlockItemPlaced;
 import org.terasology.world.block.items.OnBlockToItem;
@@ -732,7 +732,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
             Prefab selectedTemplateType = placementToSchedule.structureTemplateType;
 
             BlockFamily blockFamily = blockManager.getBlockFamily("StructureTemplates:StructurePlaceholder");
-            HorizontalBlockFamily horizontalBlockFamily = (HorizontalBlockFamily) blockFamily;
+            HorizontalFamily horizontalBlockFamily = (HorizontalFamily) blockFamily;
             Block block = horizontalBlockFamily.getBlockForSide(side);
             Vector3i positionAbove = new Vector3i(actualPosition);
             positionAbove.addY(1);
@@ -817,7 +817,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
 
     private boolean placeOriginMarkerBlockWithoutData(ActivateEvent event, Vector3i position, Side frontDirectionOfStructure) {
         BlockFamily blockFamily = blockManager.getBlockFamily("StructureTemplates:StructureTemplateOrigin");
-        HorizontalBlockFamily horizontalBlockFamily = (HorizontalBlockFamily) blockFamily;
+        HorizontalFamily horizontalBlockFamily = (HorizontalFamily) blockFamily;
         Block block = horizontalBlockFamily.getBlockForSide(frontDirectionOfStructure);
 
         PlaceBlocks placeBlocks = new PlaceBlocks(position, block, event.getInstigator());

--- a/src/main/java/org/terasology/structureTemplates/util/transform/HorizontalBlockRegionRotation.java
+++ b/src/main/java/org/terasology/structureTemplates/util/transform/HorizontalBlockRegionRotation.java
@@ -24,7 +24,7 @@ import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.family.SideDefinedBlockFamily;
 
 /**
- * Allows you to roate block regions by 90 degree.
+ * Allows you to rotate block regions by 90 degree.
  */
 public class HorizontalBlockRegionRotation implements BlockRegionTransform {
     /**
@@ -78,8 +78,8 @@ public class HorizontalBlockRegionRotation implements BlockRegionTransform {
             SideDefinedBlockFamily sideDefinedBlockFamily = (SideDefinedBlockFamily) blockFamily;
             return sideDefinedBlockFamily.getBlockForSide(transformSide(block.getDirection()));
         } else if (blockFamily instanceof AttachedToSurfaceFamily) {
-            // TODO add some proper method to block famility to not have to do this hack
-            return blockFamily.getBlockForPlacement(null, null, null, transformSide(block.getDirection()), null);
+            // TODO add some proper method to block familiy to not have to do this hack
+            return blockFamily.getBlockForPlacement(null, transformSide(block.getDirection()), null);
         }
         return block;
     }

--- a/src/test/java/org/terasology/structureTemplates/internal/systems/ScheduledStructureSpawnSystemTest.java
+++ b/src/test/java/org/terasology/structureTemplates/internal/systems/ScheduledStructureSpawnSystemTest.java
@@ -15,13 +15,14 @@
  */
 package org.terasology.structureTemplates.internal.systems;
 
+import static org.junit.Assert.assertEquals;
+import static org.terasology.structureTemplates.internal.systems.ScheduledStructureSpawnSystem.createTransformForIncomingConnectionPoint;
+
 import org.junit.Test;
 import org.terasology.math.Side;
 import org.terasology.math.geom.Vector3i;
-import org.terasology.structureTemplates.util.transform.BlockRegionTransformationList;
 
-import static org.junit.Assert.assertEquals;
-import static org.terasology.structureTemplates.internal.systems.ScheduledStructureSpawnSystem.createTransformForIncomingConnectionPoint;
+import org.terasology.structureTemplates.util.transform.BlockRegionTransformationList;
 
 /**
  * Test for {@link ScheduledStructureSpawnSystem}.


### PR DESCRIPTION
This PR fixes structure templates so they work with the new [block families](https://github.com/MovingBlocks/Terasology/tree/newBlockFamilies). This should be merged post-GCI, and after the [new block families PR](https://github.com/MovingBlocks/Terasology/pull/3149) is merged.