### PR TITLE
No construction animation and construction animation selection ui

### DIFF
--- a/assets/ui/StructureTemplatePropertiesScreen.ui
+++ b/assets/ui/StructureTemplatePropertiesScreen.ui
@@ -65,6 +65,48 @@
               },
               "id": "typeRow"
             },
+                        {
+                          "type": "engine:UILabel",
+                          "id": "titleLabel",
+                          "layoutInfo": {
+                            "position-top": {},
+                            "position-horizontal-center": {},
+                            "use-content-height": true
+                          },
+                          "text": "Structure Template Properties"
+                        },
+                        {
+                          "type": "RowLayout",
+                          "contents": [
+                            {
+                              "type": "UILabel",
+                              "text": "Select Animation: ",
+                              "layoutInfo": {
+                                "useContentWidth": true
+                              }
+                            },
+                            {
+                              "type": "UIDropdown",
+                              "multiline": false,
+                              "id": "comboBoxAnimation"
+                            }
+                          ],
+                          "layoutInfo": {
+                            "position-top": {
+                              "widget": "titleLabel",
+                              "target": "BOTTOM",
+                              "offset": 15
+                            },
+                            "position-left": {
+                              "offset": 5
+                            },
+                            "position-right": {
+                              "offset": 5
+                            },
+                            "height": 30
+                          },
+                          "id": "animationRow"
+                        },
             {
               "type": "RowLayout",
               "contents": [

--- a/src/main/java/org/terasology/structureTemplates/components/NoConstructionAnimationComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/NoConstructionAnimationComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.components;
+
+import org.terasology.entitySystem.Component;
+
+/**
+ * Add this component to a ST when neither the FallingBlock or Layer-by-Layer animation is required
+ */
+
+public class NoConstructionAnimationComponent implements Component {
+    public NoConstructionAnimationComponent() {}
+}

--- a/src/main/java/org/terasology/structureTemplates/components/StructureTemplateComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/StructureTemplateComponent.java
@@ -33,4 +33,6 @@ public class StructureTemplateComponent implements Component {
      */
     public int spawnChance = 100;
 
+    public String animationType = "Layer-by-Layer";
+
 }

--- a/src/main/java/org/terasology/structureTemplates/components/StructureTemplateComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/StructureTemplateComponent.java
@@ -17,6 +17,7 @@ package org.terasology.structureTemplates.components;
 
 import org.terasology.entitySystem.Component;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.structureTemplates.util.AnimationType;
 
 /**
  * All structure spawning entities should have this component.
@@ -33,6 +34,6 @@ public class StructureTemplateComponent implements Component {
      */
     public int spawnChance = 100;
 
-    public String animationType = "Layer-by-Layer";
+    public AnimationType animationType = AnimationType.LayerByLayer;
 
 }

--- a/src/main/java/org/terasology/structureTemplates/internal/events/RequestStructureTemplatePropertiesChange.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/events/RequestStructureTemplatePropertiesChange.java
@@ -20,6 +20,7 @@ import org.terasology.entitySystem.prefab.Prefab;
 import org.terasology.network.ServerEvent;
 import org.terasology.structureTemplates.components.StructureTemplateComponent;
 import org.terasology.structureTemplates.internal.components.StructureTemplateOriginComponent;
+import org.terasology.structureTemplates.util.AnimationType;
 
 /**
  * The event gets sent to a character entity at the server.
@@ -33,9 +34,9 @@ import org.terasology.structureTemplates.internal.components.StructureTemplateOr
 public class RequestStructureTemplatePropertiesChange implements Event {
     private Prefab prefab;
     private Integer spawnChance;
-    private String animationType;
+    private AnimationType animationType;
 
-    public RequestStructureTemplatePropertiesChange(Prefab prefab, Integer spawnChance, String animationType) {
+    public RequestStructureTemplatePropertiesChange(Prefab prefab, Integer spawnChance, AnimationType animationType) {
         this.prefab = prefab;
         this.spawnChance = spawnChance;
         this.animationType = animationType;
@@ -52,5 +53,5 @@ public class RequestStructureTemplatePropertiesChange implements Event {
         return spawnChance;
     }
 
-    public String getAnimationType() { return animationType; }
+    public AnimationType getAnimationType() { return animationType; }
 }

--- a/src/main/java/org/terasology/structureTemplates/internal/events/RequestStructureTemplatePropertiesChange.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/events/RequestStructureTemplatePropertiesChange.java
@@ -33,10 +33,12 @@ import org.terasology.structureTemplates.internal.components.StructureTemplateOr
 public class RequestStructureTemplatePropertiesChange implements Event {
     private Prefab prefab;
     private Integer spawnChance;
+    private String animationType;
 
-    public RequestStructureTemplatePropertiesChange(Prefab prefab, Integer spawnChance) {
+    public RequestStructureTemplatePropertiesChange(Prefab prefab, Integer spawnChance, String animationType) {
         this.prefab = prefab;
         this.spawnChance = spawnChance;
+        this.animationType = animationType;
     }
 
     public RequestStructureTemplatePropertiesChange() {
@@ -49,4 +51,6 @@ public class RequestStructureTemplatePropertiesChange implements Event {
     public Integer getSpawnChance() {
         return spawnChance;
     }
+
+    public String getAnimationType() { return animationType; }
 }

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
@@ -40,20 +40,11 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.network.NetworkComponent;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.BlockPlaceholderComponent;
-import org.terasology.structureTemplates.components.FallingBlocksPlacementAlgorithmComponent;
-import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
-import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent;
+import org.terasology.structureTemplates.components.*;
 import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent.RegionToFill;
-import org.terasology.structureTemplates.components.SpawnTemplateActionComponent;
-import org.terasology.structureTemplates.components.StructureTemplateComponent;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
-import org.terasology.structureTemplates.internal.components.EditTemplateRegionProcessComponent;
-import org.terasology.structureTemplates.internal.components.EditingUserComponent;
-import org.terasology.structureTemplates.internal.components.StructurePlaceholderComponent;
-import org.terasology.structureTemplates.internal.components.StructureTemplateGeneratorComponent;
-import org.terasology.structureTemplates.internal.components.StructureTemplateOriginComponent;
+import org.terasology.structureTemplates.internal.components.*;
 import org.terasology.structureTemplates.internal.events.BuildStructureTemplateStringEvent;
 import org.terasology.structureTemplates.internal.events.CopyBlockRegionResultEvent;
 import org.terasology.structureTemplates.internal.events.CreateEditTemplateRegionProcessRequest;
@@ -341,7 +332,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
         EntityBuilder entityBuilder = entityManager.newBuilder("StructureTemplates:structureSpawnItem");
         addComponentsToTemplate(structureTemplateOriginEntity, structureTemplateOriginComponent, blockComponent, entityBuilder);
         // TODO make it optional
-        entityBuilder.addOrSaveComponent(new FallingBlocksPlacementAlgorithmComponent());
+        entityBuilder.addOrSaveComponent(new NoConstructionAnimationComponent());
         EntityRef structureSpawnItem = entityBuilder.build();
 
         // TODO check permission once PermissionManager is public API

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
@@ -40,11 +40,21 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.network.NetworkComponent;
 import org.terasology.registry.In;
-import org.terasology.structureTemplates.components.*;
+import org.terasology.structureTemplates.components.BlockPlaceholderComponent;
+import org.terasology.structureTemplates.components.FallingBlocksPlacementAlgorithmComponent;
+import org.terasology.structureTemplates.components.ScheduleStructurePlacementComponent;
+import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent;
+import org.terasology.structureTemplates.components.NoConstructionAnimationComponent;
+import org.terasology.structureTemplates.components.StructureTemplateComponent;
+import org.terasology.structureTemplates.components.SpawnTemplateActionComponent;
 import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent.RegionToFill;
 import org.terasology.structureTemplates.events.BuildStructureTemplateEntityEvent;
 import org.terasology.structureTemplates.events.SpawnTemplateEvent;
-import org.terasology.structureTemplates.internal.components.*;
+import org.terasology.structureTemplates.internal.components.EditTemplateRegionProcessComponent;
+import org.terasology.structureTemplates.internal.components.EditingUserComponent;
+import org.terasology.structureTemplates.internal.components.StructurePlaceholderComponent;
+import org.terasology.structureTemplates.internal.components.StructureTemplateGeneratorComponent;
+import org.terasology.structureTemplates.internal.components.StructureTemplateOriginComponent;
 import org.terasology.structureTemplates.internal.events.BuildStructureTemplateStringEvent;
 import org.terasology.structureTemplates.internal.events.CopyBlockRegionResultEvent;
 import org.terasology.structureTemplates.internal.events.CreateEditTemplateRegionProcessRequest;
@@ -55,6 +65,7 @@ import org.terasology.structureTemplates.internal.events.RequestStructurePlaceho
 import org.terasology.structureTemplates.internal.events.RequestStructureTemplatePropertiesChange;
 import org.terasology.structureTemplates.internal.events.StopEditingProcessRequest;
 import org.terasology.structureTemplates.internal.events.StructureTemplateStringRequest;
+import org.terasology.structureTemplates.util.AnimationType;
 import org.terasology.structureTemplates.util.ListUtil;
 import org.terasology.structureTemplates.util.RegionMergeUtil;
 import org.terasology.structureTemplates.util.BlockRegionTransform;
@@ -385,10 +396,10 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
                                                 StructureTemplateComponent componentOfEditor) {
         MutableComponentContainer templateEntity = event.getTemplateEntity();
         templateEntity.addOrSaveComponent(componentLibrary.copy(componentOfEditor));
-        if (componentOfEditor.animationType == "Falling Block") {
+        if (componentOfEditor.animationType == AnimationType.FallingBlock) {
             templateEntity.addOrSaveComponent(new FallingBlocksPlacementAlgorithmComponent());
         }
-        else if (componentOfEditor.animationType == "No animation") {
+        else if (componentOfEditor.animationType == AnimationType.NoAnimation) {
             templateEntity.addOrSaveComponent(new NoConstructionAnimationComponent());
         }
     }

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
@@ -263,6 +263,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
 
         structureTemplateComponent.type = event.getPrefab();
         structureTemplateComponent.spawnChance = event.getSpawnChance();
+        structureTemplateComponent.animationType = event.getAnimationType();
         interactionTarget.saveComponent(structureTemplateComponent);
     }
 
@@ -332,7 +333,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
         EntityBuilder entityBuilder = entityManager.newBuilder("StructureTemplates:structureSpawnItem");
         addComponentsToTemplate(structureTemplateOriginEntity, structureTemplateOriginComponent, blockComponent, entityBuilder);
         // TODO make it optional
-        entityBuilder.addOrSaveComponent(new NoConstructionAnimationComponent());
+        //entityBuilder.addOrSaveComponent(new NoConstructionAnimationComponent());
         EntityRef structureSpawnItem = entityBuilder.build();
 
         // TODO check permission once PermissionManager is public API
@@ -384,6 +385,12 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
                                                 StructureTemplateComponent componentOfEditor) {
         MutableComponentContainer templateEntity = event.getTemplateEntity();
         templateEntity.addOrSaveComponent(componentLibrary.copy(componentOfEditor));
+        if (componentOfEditor.animationType == "Falling Block") {
+            templateEntity.addOrSaveComponent(new FallingBlocksPlacementAlgorithmComponent());
+        }
+        else if (componentOfEditor.animationType == "No animation") {
+            templateEntity.addOrSaveComponent(new NoConstructionAnimationComponent());
+        }
     }
 
     @ReceiveEvent
@@ -463,6 +470,24 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
         sb.append("        ]\n");
         sb.append("    }");
         event.addJsonForComponent(sb.toString(), SpawnBlockRegionsComponent.class);
+    }
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void onBuildTemplateStringWithBlockRegions(BuildStructureTemplateStringEvent event, EntityRef template,
+                                                      FallingBlocksPlacementAlgorithmComponent component) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("    \"FallingBlockPlacementAlgorithm\": {\n");
+        sb.append("    }");
+        event.addJsonForComponent(sb.toString(), FallingBlocksPlacementAlgorithmComponent.class);
+    }
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void onBuildTemplateStringWithBlockRegions(BuildStructureTemplateStringEvent event, EntityRef template,
+                                                      NoConstructionAnimationComponent component) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("    \"NoConstructionAnimation\": {\n");
+        sb.append("    }");
+        event.addJsonForComponent(sb.toString(), NoConstructionAnimationComponent.class);
     }
 
     @ReceiveEvent

--- a/src/main/java/org/terasology/structureTemplates/internal/ui/StructureTemplatePropertiesScreen.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/ui/StructureTemplatePropertiesScreen.java
@@ -31,6 +31,7 @@ import org.terasology.rendering.nui.widgets.UIText;
 import org.terasology.structureTemplates.components.StructureTemplateComponent;
 import org.terasology.structureTemplates.components.StructureTemplateTypeComponent;
 import org.terasology.structureTemplates.internal.events.RequestStructureTemplatePropertiesChange;
+import org.terasology.structureTemplates.util.AnimationType;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -42,13 +43,13 @@ import java.util.List;
 public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
 
     private UIDropdown<Prefab> comboBox;
-    private UIDropdown<String> comboBoxAnimation;
+    private UIDropdown<AnimationType> comboBoxAnimation;
     private UIText spawnChanceTextBox;
     private UIButton closeButton;
 
     private String spawnChanceString;
     private Prefab selectedPrefab;
-    private String animationType;
+    private AnimationType animationType;
 
     private EntityRef editorEntity;
 
@@ -124,20 +125,34 @@ public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
 
         comboBoxAnimation = find("comboBoxAnimation", UIDropdown.class);
         if (comboBoxAnimation != null) {
-            List<String> animations = new ArrayList<>();
-            animations.add("Layer-by-Layer");
-            animations.add("Falling Block");
-            animations.add("No animation");
+            List<AnimationType> animations = new ArrayList<>();
+            animations.add(AnimationType.LayerByLayer);
+            animations.add(AnimationType.FallingBlock);
+            animations.add(AnimationType.NoAnimation);
             comboBoxAnimation.setOptions(animations);
-
-            comboBoxAnimation.bindSelection(new Binding<String>() {
+            comboBoxAnimation.setOptionRenderer(new StringTextRenderer<AnimationType>() {
                 @Override
-                public String get() {
+                public String getString(AnimationType value) {
+                    switch (value) {
+                        case NoAnimation:
+                            return "No animation";
+
+                        case FallingBlock:
+                            return "Falling Block";
+
+                        default:
+                            return "Layer-by-Layer";
+                    }
+                }
+            });
+            comboBoxAnimation.bindSelection(new Binding<AnimationType>() {
+                @Override
+                public AnimationType get() {
                     return animationType;
                 }
 
                 @Override
-                public void set(String value) {
+                public void set(AnimationType value) {
                     animationType = value;
                     requestServerToTakeOverCurrentValues();
                 }

--- a/src/main/java/org/terasology/structureTemplates/internal/ui/StructureTemplatePropertiesScreen.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/ui/StructureTemplatePropertiesScreen.java
@@ -42,11 +42,13 @@ import java.util.List;
 public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
 
     private UIDropdown<Prefab> comboBox;
+    private UIDropdown<String> comboBoxAnimation;
     private UIText spawnChanceTextBox;
     private UIButton closeButton;
 
     private String spawnChanceString;
     private Prefab selectedPrefab;
+    private String animationType;
 
     private EntityRef editorEntity;
 
@@ -66,6 +68,7 @@ public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
         StructureTemplateComponent comp = editorEntity.getComponent(StructureTemplateComponent.class);
         selectedPrefab = comp.type;
         spawnChanceString = Integer.toString(comp.spawnChance);
+        animationType = comp.animationType;
     }
 
 
@@ -119,6 +122,28 @@ public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
             });
         }
 
+        comboBoxAnimation = find("comboBoxAnimation", UIDropdown.class);
+        if (comboBoxAnimation != null) {
+            List<String> animations = new ArrayList<>();
+            animations.add("Layer-by-Layer");
+            animations.add("Falling Block");
+            animations.add("No animation");
+            comboBoxAnimation.setOptions(animations);
+
+            comboBoxAnimation.bindSelection(new Binding<String>() {
+                @Override
+                public String get() {
+                    return animationType;
+                }
+
+                @Override
+                public void set(String value) {
+                    animationType = value;
+                    requestServerToTakeOverCurrentValues();
+                }
+            });
+        }
+
         closeButton = find("closeButton", UIButton.class);
         if (closeButton != null) {
             closeButton.subscribe(this::onCloseButton);
@@ -141,7 +166,7 @@ public class StructureTemplatePropertiesScreen extends CoreScreenLayer {
         } catch (NumberFormatException e) {
             spawnChance = 0;
         }
-        localPlayer.getCharacterEntity().send(new RequestStructureTemplatePropertiesChange(selectedPrefab, spawnChance));
+        localPlayer.getCharacterEntity().send(new RequestStructureTemplatePropertiesChange(selectedPrefab, spawnChance, animationType));
 
     }
 }

--- a/src/main/java/org/terasology/structureTemplates/util/AnimationType.java
+++ b/src/main/java/org/terasology/structureTemplates/util/AnimationType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.util;
+
+public enum AnimationType {
+    LayerByLayer,
+    FallingBlock,
+    NoAnimation
+}


### PR DESCRIPTION
This PR :
- adds a new `NoConstructionAnimationComponent` which can be added to an ST if no construction animation is to be used.
- adds a `Select animation` dropdown to the Structure Template Properties screen which can be used to select an animation from `Layer-by-Layer`, `Falling Block` and `No animation`. By default an ST will be constructed using the Layer-by-Layer animation.