### PR TITLE
Fix bottom centre block region calculation

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionUtilities.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionUtilities.java
@@ -30,7 +30,7 @@ public class BlockRegionUtilities {
      */
     public static Vector3i determineBottomCenter(SpawnBlockRegionsComponent spawnBlockRegionsComponent) {
         Vector3f bbCenter = getBoundingBox(spawnBlockRegionsComponent).center();
-        Vector3i center = new Vector3i(-bbCenter.x, (float) getBoundingBox(spawnBlockRegionsComponent).minY(), -bbCenter.z);
+        Vector3i center = new Vector3i(bbCenter.x, (float) getBoundingBox(spawnBlockRegionsComponent).minY(), bbCenter.z);
 
         return center;
     }


### PR DESCRIPTION
## Contains

A fix for `BlockRegionUtilities.determineBottomCenter`, where the x & z coordinates are inverted, resulting in a point sometimes outside of the bounding box.

*Could potentially break compatibility with modules using the old version of this calculation, a version update may be needed*

Required for Terasology/DynamicCities#49 to work properly.