### PR TITLE
feat: Add functionality to ignore air blocks

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/components/IgnoreAirBlocksComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/IgnoreAirBlocksComponent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.structureTemplates.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.world.block.BlockComponent;
+
+// Used as a marker component for Structures that don't need explicit spawning of air blocks.
+// TODO : Generalise for all kind of Blocks
+// TODO : Add marker component to toolbox UI
+public class IgnoreAirBlocksComponent implements Component {
+}

--- a/src/main/java/org/terasology/structureTemplates/components/IgnoreAirBlocksComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/components/IgnoreAirBlocksComponent.java
@@ -18,7 +18,7 @@ package org.terasology.structureTemplates.components;
 import org.terasology.entitySystem.Component;
 import org.terasology.world.block.BlockComponent;
 
-// Used as a marker component for Structures that don't need explicit spawning of air blocks.
+/** A marker component for structures that don't need explicit spawning of air blocks. */
 // TODO : Generalise for all kind of Blocks
 // TODO : Add marker component to toolbox UI
 public class IgnoreAirBlocksComponent implements Component {

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -127,7 +127,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
         for (RegionToFill regionToFill : spawnBlockRegionsComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
+            if (entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
 
@@ -171,7 +171,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         Map<Integer, List<BlockToPlace>> blocksPerLayer = Maps.newTreeMap();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
+            if (entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
             
@@ -207,7 +207,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         BlockRegionTransform transformation = event.getTransformation();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
+            if (entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
 
@@ -290,6 +290,10 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
         entity.send(new SpawnStructureEvent(blockRegionTransform));
 
+    }
+    
+    private boolean isAir(final Block block) {
+        return block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn());
     }
 
     // TODO move method into utility class:

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -67,8 +67,9 @@ import org.terasology.structureTemplates.util.BlockRegionTransform;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockComponent;
-
+import org.terasology.structureTemplates.components.IgnoreAirBlocksComponent;
 import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.family.BlockFamily;
 
 
 /**
@@ -126,8 +127,11 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
         for (RegionToFill regionToFill : spawnBlockRegionsComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-
-            Region3i region = regionToFill.region;
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
+            {
+                continue;
+            }
+                Region3i region = regionToFill.region;
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
@@ -167,8 +171,11 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         Map<Integer, List<BlockToPlace>> blocksPerLayer = Maps.newTreeMap();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-
-            Region3i region = regionToFill.region;
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
+            {
+                continue;
+            }
+                Region3i region = regionToFill.region;
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
@@ -200,7 +207,10 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         BlockRegionTransform transformation = event.getTransformation();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
+            {
+                continue;
+            }
 
             Region3i region = regionToFill.region;
             region = transformation.transformRegion(region);

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -127,11 +127,11 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
         for (RegionToFill regionToFill : spawnBlockRegionsComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
-            {
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
-                Region3i region = regionToFill.region;
+
+            Region3i region = regionToFill.region;
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
@@ -171,11 +171,11 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         Map<Integer, List<BlockToPlace>> blocksPerLayer = Maps.newTreeMap();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
-            {
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
-                Region3i region = regionToFill.region;
+            
+            Region3i region = regionToFill.region;
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
@@ -207,8 +207,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
         BlockRegionTransform transformation = event.getTransformation();
         for (RegionToFill regionToFill : spawnBlockRegionComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if(entity.hasComponent(IgnoreAirBlocksComponent.class)&&block.getURI().getBlockFamilyDefinitionUrn().equals(BlockManager.AIR_ID.getBlockFamilyDefinitionUrn()))
-            {
+            if(entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
 

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -127,7 +127,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
         for (RegionToFill regionToFill : spawnBlockRegionsComponent.regionsToFill) {
             Block block = regionToFill.blockType;
-            if (entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
+            if (entity.hasComponent(IgnoreAirBlocksComponent.class) && isAir(block)) {
                 continue;
             }
 


### PR DESCRIPTION
Closes https://github.com/Terasology/StructureTemplates/issues/3. 

Added a new marker component to enable ignoring of air blocks while spawning a structure template.