### PR TITLE
fix: NPE upon spawning structure template in edit mode

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -159,6 +159,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void onSpawnTemplateEventWithBlocksPriority(SpawnTemplateEvent event, EntityRef entity) {
+        structureEntity = entity;
         entity.send(new SpawnBlocksOfStructureTemplateEvent(event.getTransformation()));
     }
 


### PR DESCRIPTION
- How to reproduce the bug:

1. Use an existing Structure Template item('T' tile) (Not to be confused with Structure Template spawner) by getting it from the toolbox.
2. This should spawn the structure for editing but instead a NPE is thrown.

