### PR TITLE
fix: union regions instead of min and max

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksForMidAirEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/GetStructureTemplateBlocksForMidAirEvent.java
@@ -22,6 +22,7 @@ import org.terasology.structureTemplates.util.BlockRegionTransform;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,8 +48,8 @@ public class GetStructureTemplateBlocksForMidAirEvent implements Event {
     }
 
     public void fillRegion(BlockRegion region, Block block) {
-        for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
-            blocksToPlace.put(new Vector3i(pos), block);
+        for (Vector3i pos : BlockRegions.iterable(region)) {
+            blocksToPlace.put(pos, block);
         }
     }
 }

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/ReplaceWallServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/ReplaceWallServerSystem.java
@@ -34,6 +34,7 @@ import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.block.entity.placement.PlaceBlocks;
 
 import java.util.HashMap;
@@ -62,7 +63,7 @@ public class ReplaceWallServerSystem extends BaseComponentSystem {
         Block block = blockManager.getBlock(component.blockUri);
         Map<Vector3i, Block> map = new HashMap<>();
         for (BlockRegion region: previewComponent.wallRegions) {
-            for (Vector3ic v: BlockRegionIterable.region(region).build()) {
+            for (Vector3ic v: BlockRegions.iterableInPlace(region)) {
                 map.put(new Vector3i(JomlUtil.from(v)), block);
             }
         }

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -65,6 +65,7 @@ import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 
 import java.util.List;
 import java.util.Map;
@@ -134,7 +135,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
-            for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
+            for (Vector3ic pos : BlockRegions.iterableInPlace(region)) {
                 blocksToPlace.put(JomlUtil.from(pos), block);
             }
         }
@@ -179,7 +180,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
 
-            for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
+            for (Vector3ic pos : BlockRegions.iterableInPlace(region)) {
                 final int y = pos.y();
                 if (!blocksPerLayer.containsKey(y)) {
                     blocksPerLayer.put(y, Lists.newArrayList());

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureTemplateEditorServerSystem.java
@@ -78,6 +78,7 @@ import org.terasology.world.block.BlockComponent;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.block.entity.placement.PlaceBlocks;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.family.HorizontalFamily;
@@ -623,7 +624,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
 
         Map<Block, Set<Vector3i>> map = new HashMap<>();
         for (BlockRegion absoluteRegion : absoluteRegions) {
-            for (Vector3ic absolutePosition : BlockRegionIterable.region(absoluteRegion).build()) {
+            for (Vector3ic absolutePosition : BlockRegions.iterableInPlace(absoluteRegion)) {
                 Block block = worldProvider.getBlock(absolutePosition);
                 Set<Vector3i> positions = map.get(block);
                 if (positions == null) {
@@ -643,7 +644,7 @@ public class StructureTemplateEditorServerSystem extends BaseComponentSystem {
 
         List<RegionToFill> regionsToFill = new ArrayList<>();
         for (BlockRegion absoluteRegion : absoluteRegions) {
-            for (Vector3ic absolutePosition : BlockRegionIterable.region(absoluteRegion).build()) {
+            for (Vector3ic absolutePosition : BlockRegions.iterableInPlace(absoluteRegion)) {
                 EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(absolutePosition);
                 BlockPlaceholderComponent placeholderComponent = blockEntity.getComponent(BlockPlaceholderComponent.class);
                 Block block;

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -92,10 +92,9 @@ public class BlockRegionTransform {
 
 
     public BlockRegion transformRegion(BlockRegion region) {
-        return new BlockRegion(
-        	transformVector3i(region.getMin(new Vector3i())),
-        	transformVector3i(region.getMax(new Vector3i()))).correctBounds();
-
+        return new BlockRegion().union(
+            transformVector3i(region.getMin(new Vector3i()))).union(
+            transformVector3i(region.getMax(new Vector3i())));
     }
 
     public Block transformBlock(Block block) {

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -92,7 +92,10 @@ public class BlockRegionTransform {
 
 
     public BlockRegion transformRegion(BlockRegion region) {
-        return new BlockRegion().union(transformVector3i(region.getMin(new Vector3i()))).union(
+        return new BlockRegion(
+        	transformVector3i(region.getMin(new Vector3i())),
+        	transformVector3i(region.getMax(new Vector3i()))).correctBounds();
+
             transformVector3i(region.getMax(new Vector3i())));
     }
 

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -94,9 +94,8 @@ public class BlockRegionTransform {
     public BlockRegion transformRegion(BlockRegion region) {
         return new BlockRegion(
         	transformVector3i(region.getMin(new Vector3i())),
-        	transformVector3i(region.getMax(new Vector3i())).correctBounds();
+        	transformVector3i(region.getMax(new Vector3i()))).correctBounds();
 
-            transformVector3i(region.getMax(new Vector3i())));
     }
 
     public Block transformBlock(Block block) {

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -92,7 +92,7 @@ public class BlockRegionTransform {
 
 
     public BlockRegion transformRegion(BlockRegion region) {
-        return new BlockRegion(transformVector3i(region.getMin(new Vector3i())),
+        return new BlockRegion().union(transformVector3i(region.getMin(new Vector3i()))).union(
             transformVector3i(region.getMax(new Vector3i())));
     }
 

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -92,9 +92,9 @@ public class BlockRegionTransform {
 
 
     public BlockRegion transformRegion(BlockRegion region) {
-        return new BlockRegion().union(
-            transformVector3i(region.getMin(new Vector3i()))).union(
-            transformVector3i(region.getMax(new Vector3i())));
+        return new BlockRegion()
+                .union(transformVector3i(region.getMin(new Vector3i())))
+                .union(transformVector3i(region.getMax(new Vector3i())));
     }
 
     public Block transformBlock(Block block) {

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -94,7 +94,7 @@ public class BlockRegionTransform {
     public BlockRegion transformRegion(BlockRegion region) {
         return new BlockRegion(
         	transformVector3i(region.getMin(new Vector3i())),
-        	transformVector3i(region.getMax(new Vector3i()))).correctBounds();
+        	transformVector3i(region.getMax(new Vector3i())).correctBounds();
 
             transformVector3i(region.getMax(new Vector3i())));
     }

--- a/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
+++ b/src/main/java/org/terasology/structureTemplates/util/BlockRegionTransform.java
@@ -87,7 +87,8 @@ public class BlockRegionTransform {
     }
 
     public Region3i transformRegion(Region3i region) {
-        return Region3i.createBounded(JomlUtil.from(transformVector3i(JomlUtil.from(region.min()))), JomlUtil.from(transformVector3i(JomlUtil.from(region.max()))));
+        return Region3i.createBounded(JomlUtil.from(transformVector3i(JomlUtil.from(region.min()))),
+                JomlUtil.from(transformVector3i(JomlUtil.from(region.max()))));
     }
 
 
@@ -104,7 +105,8 @@ public class BlockRegionTransform {
             return sideDefinedBlockFamily.getBlockForSide(transformSide(block.getDirection()));
         } else if (blockFamily instanceof AttachedToSurfaceFamily) {
             // TODO add some proper method to block famility to not have to do this hack
-            return blockFamily.getBlockForPlacement(new BlockPlacementData(new Vector3i(), transformSide(block.getDirection()), new Vector3f()));
+            return blockFamily.getBlockForPlacement(new BlockPlacementData(new Vector3i(),
+                    transformSide(block.getDirection()), new Vector3f()));
         }
         return block;
     }
@@ -115,7 +117,7 @@ public class BlockRegionTransform {
 
     public Vector3i transformVector3i(Vector3i vectorToTransform) {
         Vector3i result = vectorRotatedClockWiseHorizontallyNTimes(vectorToTransform,
-            counterClockWiseHorizontal90DegreeRotations);
+                counterClockWiseHorizontal90DegreeRotations);
         result.add(offset);
         return result;
     }
@@ -160,7 +162,8 @@ public class BlockRegionTransform {
     }
 
     public static BlockRegionTransform createFromComponent(BlockRegionTransformComponent component) {
-        return new BlockRegionTransform(component.counterClockWiseHorizontal90DegreeRotations, JomlUtil.from(component.offset));
+        return new BlockRegionTransform(component.counterClockWiseHorizontal90DegreeRotations,
+                JomlUtil.from(component.offset));
     }
 
     /**

--- a/src/main/java/org/terasology/structureTemplates/util/RegionMergeUtil.java
+++ b/src/main/java/org/terasology/structureTemplates/util/RegionMergeUtil.java
@@ -21,6 +21,7 @@ import org.terasology.math.JomlUtil;
 import org.terasology.structureTemplates.components.SpawnBlockRegionsComponent;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -65,7 +66,7 @@ public final class RegionMergeUtil {
     public static Set<org.terasology.math.geom.Vector3i> positionsOfRegions(List<BlockRegion> originalRegions) {
         Set<org.terasology.math.geom.Vector3i> positionsInTemplate = new HashSet<>();
         for (BlockRegion region : originalRegions) {
-            for (Vector3ic position : BlockRegionIterable.region(region).build()) {
+            for (Vector3ic position : BlockRegions.iterableInPlace(region)) {
                 positionsInTemplate.add(JomlUtil.from(new Vector3i(position)));
             }
         }


### PR DESCRIPTION
this fixes a problem when blockregions are rotated since the min and max end up reversed. 

Depends on https://github.com/MovingBlocks/Terasology/pull/4272 and https://github.com/Terasology/DynamicCities/pull/73