### PR TITLE
fix: create new vector instances when filling `blocksToPlace`

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/events/SpawnStructureEvent.java
+++ b/src/main/java/org/terasology/structureTemplates/events/SpawnStructureEvent.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.structureTemplates.events;
 
 import org.terasology.engine.entitySystem.event.AbstractConsumableEvent;
@@ -25,11 +12,11 @@ import org.terasology.structureTemplates.util.BlockRegionTransform;
  *
  * <ul>
  *     <li>It must send at the start a {@link StructureSpawnStartedEvent}. Other event handlers might use it to trigger
- *     stuff. E.g. handlers of {@link StructureSpawnStartedEvent} might display soem particles or play a round
+ *     stuff. E.g. handlers of {@link StructureSpawnStartedEvent} might display some particles or play a sound
  *     when a certain component is present.</li>
  *     <li>It may place the blocks instantly or delayed. Possibly triggering a nice animation.
  *     To get the blocks to place it can send a {@link GetStructureTemplateBlocksEvent}.
- *     Alternativly it can also send a {@link SpawnBlocksOfStructureTemplateEvent} event to trigger
+ *     Alternatively, it can also send a {@link SpawnBlocksOfStructureTemplateEvent} event to trigger
  *     the default block spawning</li>
  *     <li>After all blocks have been spawned it must send a {@link StructureBlocksSpawnedEvent}.
  *     The {@link StructureBlocksSpawnedEvent} triggers further structure finish up work like the placement of items

--- a/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/systems/StructureSpawnServerSystem.java
@@ -133,7 +133,7 @@ public class StructureSpawnServerSystem extends BaseComponentSystem {
             block = transformation.transformBlock(block);
 
             for (Vector3ic pos : region) {
-                blocksToPlace.put(pos, block);
+                blocksToPlace.put(new Vector3i(pos), block);
             }
         }
 


### PR DESCRIPTION
When iterating over the positions in the block region we reuse the same vector instance. When storing those positions in a map we need to create a copy of the vector to avoid unwanted mutation.

With this change, it is again possible to place structure templates with the `NoConstructionAnimationComponent`.
