### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/structureTemplates/internal/components/BuildStepwiseStructureComponent.java
+++ b/src/main/java/org/terasology/structureTemplates/internal/components/BuildStepwiseStructureComponent.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
  * TODO: add javadoc
  */
 public class BuildStepwiseStructureComponent implements Component<BuildStepwiseStructureComponent> {
-    private List<BuildStep> buildSteps;
+    public List<BuildStep> buildSteps;
 
     public BuildStepwiseStructureComponent(List<BuildStep> buildSteps) {
         this.buildSteps = buildSteps;


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191